### PR TITLE
Add .gitignore to template

### DIFF
--- a/cli/template/.gitignore
+++ b/cli/template/.gitignore
@@ -1,0 +1,7 @@
+/node_modules
+
+/.static/
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
The generated template currently doesn't have a `.gitignore` file.

This PR add a basic `.gitignore` to generated template app